### PR TITLE
タスクの新規作成ダイアログと、ホームとタスク一覧ページ用のタスク追加ボタンのコンポーネントを作成。

### DIFF
--- a/frontend/components/Task/AddFAB.vue
+++ b/frontend/components/Task/AddFAB.vue
@@ -1,5 +1,6 @@
 <!--
 categoryData:      カテゴリの情報をもつ配列
+tasks:             全てのタスクのデータ
 @task:created:     タスクの保存ボタンを押した時に発火するイベント
                    タスクオブジェクトを返す
                    {
@@ -31,9 +32,9 @@ categoryData:      カテゴリの情報をもつ配列
 
     <TaskCreate
       activator="#activator"
-      taskId=""
       :isDone="false"
       :categoryData="categoryData"
+      :tasks="tasks"
       @task:created="createTask($event)"
       @category:updated="updateCategoryData($event)"
       @category:created="addCategoryData($event)"
@@ -46,6 +47,10 @@ export default {
   props: {
     categoryData: {
       type: Object,
+      required: true
+    },
+    tasks: {
+      type: Array,
       required: true
     }
   },

--- a/frontend/components/Task/AddFAB.vue
+++ b/frontend/components/Task/AddFAB.vue
@@ -1,0 +1,68 @@
+<!--
+categoryData:      カテゴリの情報をもつ配列
+@task:created:     タスクの保存ボタンを押した時に発火するイベント
+                   タスクオブジェクトを返す
+                   {
+                     'id': this.taskId,
+                     'name': this.editableTaskName,
+                     'categories': this.editableCategories,
+                     'isDone': this.editableIsDone,
+                     'date': this.editableTaskDate,
+                     'detail': this.editableTaskDetail
+                   }
+@category:updated: カテゴリが更新されたときに発火するイベント
+                   新しいカテゴリデータを返す。{ '0005': {'name': 'タスク名', 'color': '#XXXXXX'} }
+@category:created: カテゴリが新規作成されたときに発火するイベント
+                   新しいカテゴリデータを返す。{ '0005': {'name': 'タスク名', 'color': '#XXXXXX'} }
+-->
+<template>
+  <div class="task-add-fab">
+    <v-btn
+      id="activator"
+      fab
+      fixed
+      right
+      elevation="8"
+      color="primary"
+      style="bottom: 64px;"
+    >
+      <v-icon>mdi-plus</v-icon>
+    </v-btn>
+
+    <TaskCreate
+      activator="#activator"
+      taskId=""
+      :isDone="false"
+      :categoryData="categoryData"
+      @task:created="createTask($event)"
+      @category:updated="updateCategoryData($event)"
+      @category:created="addCategoryData($event)"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    categoryData: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    createTask(createdTaskData) {
+      this.$emit('task:created', createdTaskData)
+    },
+    updateCategoryData(updatedCategoryData) {
+      this.$emit('category:updated', updatedCategoryData)
+    },
+    addCategoryData(newCategoryData) {
+      this.$emit('category:created', newCategoryData)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/frontend/components/Task/AddFAB.vue
+++ b/frontend/components/Task/AddFAB.vue
@@ -22,10 +22,9 @@ tasks:             全てのタスクのデータ
       id="activator"
       fab
       fixed
-      right
       elevation="8"
       color="primary"
-      style="bottom: 64px;"
+      style="bottom: 64px; right: 8px;"
     >
       <v-icon>mdi-plus</v-icon>
     </v-btn>

--- a/frontend/components/Task/Create.vue
+++ b/frontend/components/Task/Create.vue
@@ -1,0 +1,348 @@
+<!--
+activator:         ダイアログを起動させるためのエレメントをセレクタで指定。例):activator="#activator"
+taskId:            表示するタスクのID
+taskName:          表示するタスクのタイトル
+taskDate:          表示するタスクの最新の表示日
+taskDetail:        表示するタスクの内容
+categories:        表示するタスクに設定されたカテゴリの配列
+isDone:            表示するタスクが完了しているかどうか
+categoryData:      カテゴリの情報をもつ配列
+@task:created:     タスクの保存ボタンを押した時に発火するイベント
+                   タスクオブジェクトを返す
+                   {
+                     'id': this.taskId,
+                     'name': this.editableTaskName,
+                     'categories': this.editableCategories,
+                     'isDone': this.editableIsDone,
+                     'date': this.editableTaskDate,
+                     'detail': this.editableTaskDetail
+                   }
+@category:updated: カテゴリが更新されたときに発火するイベント
+                   新しいカテゴリデータを返す。{ '0005': {'name': 'タスク名', 'color': '#XXXXXX'} }
+@category:created: カテゴリが新規作成されたときに発火するイベント
+                   新しいカテゴリデータを返す。{ '0005': {'name': 'タスク名', 'color': '#XXXXXX'} }
+-->
+<template>
+  <div class="task-info">
+    <v-dialog
+      v-model="dialog"
+      :activator="activator"
+      fullscreen
+      scrollable
+    >
+      <!-- タスクの詳細を表示するダイアログ -->
+      <v-card tile>
+        <!-- scrollableプロパティに対応するためv-card-titleを使う -->
+        <v-card-title class="pa-0">
+          <v-toolbar
+            dark
+            flat
+            color="primary"
+          >
+            <!-- タスクの変更ダイアログを閉じる -->
+            <v-btn
+              icon
+              @click="closeDialog"
+            >
+              <v-icon>mdi-arrow-left</v-icon>
+            </v-btn>
+            <v-toolbar-title>タスクの追加</v-toolbar-title>
+            <v-spacer></v-spacer>
+            <v-toolbar-items>
+              <!-- 保存ボタン -->
+              <v-btn
+                icon
+                @click="createTask"
+                :disabled="!canChangeData"
+              >
+                <v-icon>mdi-check</v-icon>
+              </v-btn>
+            </v-toolbar-items>
+          </v-toolbar>
+        </v-card-title>
+        
+        <!-- scrollableプロパティに対応するためv-card-textを使う -->
+        <v-card-text>
+          <v-list
+            three-line
+            subheader
+          >
+            <v-subheader>基本情報</v-subheader>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>タスクタイトル</v-list-item-title>
+
+                <v-text-field
+                  v-model="editableTaskName"
+                  single-line
+                  outlined
+                  clearable
+                  placeholder="タスク名"
+                  autofocus
+                  class="mt-1"
+                >
+                </v-text-field>
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>直近の表示日</v-list-item-title>
+
+                <UserFormSingleDate
+                  v-model="editableTaskDate"
+                  placeholder="2021-01-01"
+                />
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-list-item>
+              <v-list-item-content style="position: relative;">
+                <v-list-item-title>
+                  カテゴリ
+                </v-list-item-title>
+                <v-btn
+                  id="open-category-selector"
+                  text
+                  color="secondary"
+                  style="position: absolute; top: 5px; right: 0;"
+                  @click.stop="openCategorySelector"
+                >
+                  <v-icon>mdi-plus-circle-outline</v-icon>
+                  カテゴリーを選択
+                </v-btn>
+                
+                <TaskCategoryList
+                  v-if="editableCategories[0]"
+                  :clearable="true"
+                  @click:clear="deleteCategory($event)"
+                  :categories="editableCategories"
+                  :categoryData="categoryData"
+                  class="mt-2"
+                />
+                <v-list-item-subtitle v-else>カテゴリが設定されていません</v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>内容</v-list-item-title>
+                <v-textarea
+                  v-model="editableTaskDetail"
+                  outlined
+                  rows="6"
+                  auto-grow
+                  no-resize
+                  hint="教材のページやURLなどを記入すると便利です"
+                  persistent-hint
+                  placeholder="タスク内容をここに入力できます。"
+                  class="mt-1"
+                >
+                </v-textarea>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+          
+        </v-card-text>
+
+      </v-card>
+    </v-dialog>
+
+    <!-- カテゴリを選択するダイアログ -->
+    <v-dialog
+      v-model="categorySelector"
+      scrollable
+      max-width="400"
+      @click:outside="$refs.categorySelector.save(), closeCategorySelector()"
+    >
+      <TaskCategorySelector
+        ref="categorySelector"
+        :categories="editableCategories"
+        :categoryData="categoryData"
+        @back="closeCategorySelector()"
+        @editCategory="openCategoryEditor($event)"
+        @createNewCategory="openCategoryEditor(''), closeCategorySelector()"
+        @change="editableCategories = $event"
+      />
+    </v-dialog>
+
+    <!-- カテゴリを新規作成・編集するエディタ -->
+    <v-dialog
+      v-model="categoryEditor"
+      scrollable
+      max-width="400"
+      @click:outside="openCategorySelector(), closeCategoryEditor()"
+    >
+      <TaskCategoryEditor
+        :id="categoryIdForEditor"
+        :name="categoryNameForEditor"
+        :color="categoryColorForEditor"
+        @back="openCategorySelector(), closeCategoryEditor()"
+        @done="openCategorySelector(), closeCategoryEditor()"
+        @category:created="addCategoryData($event)"
+        @category:updated="updateCategoryData($event)"
+      />
+    </v-dialog>
+
+    <!-- タスク追加時に表示されるお知らせ -->
+    <v-snackbar
+      v-model="snackbarCreate"
+      timeout="4000"
+      color="secondary"
+    >
+      タスクを追加しました。
+    </v-snackbar>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    activator: {
+      type: String,
+      required: true
+    },
+    taskId: {
+      type: String,
+      required: true
+    },
+    taskName: {
+      type: String,
+      default: ""
+    },
+    categories: {
+      type: Array,
+      default: []
+    },
+    isDone: {
+      type: Boolean,
+      default: false
+    },
+    taskDate: {
+      type: String,
+      default: ""
+    },
+    taskDetail: {
+      type: String,
+      default: ""
+    },
+    categoryData: {
+      type: Object
+    },
+  },
+  data() {
+    return {
+      dialog: false,
+      snackbarCreate: false,
+      categorySelector: false,
+      categoryEditor: false,
+      categoryIdForEditor: '',
+      editableTaskName: String,
+      editableCategories: Array,
+      editableIsDone: Boolean,
+      editableTaskDate: String,
+      editableTaskDetail: String
+    }
+  },
+  computed: {
+    edited: function() {
+      if (
+        this.taskName == this.editableTaskName
+        && JSON.stringify(this.categories) == JSON.stringify(this.editableCategories)
+        && this.isDone == this.editableIsDone
+        && this.taskDate == this.editableTaskDate
+        && this.taskDetail == this.editableTaskDetail
+      ) {
+        return false
+      } else {
+        return true
+      }
+    },
+    canChangeData: function() {
+      if (this.edited && this.editableTaskName && this.editableTaskDate) {
+        return true
+      } else {
+        return false
+      }
+    },
+    categoryNameForEditor: {
+      get() {
+        return this.categoryIdForEditor ? this.categoryData[this.categoryIdForEditor].name : ''
+      }
+    },
+    categoryColorForEditor: {
+      get() {
+        return this.categoryIdForEditor ? this.categoryData[this.categoryIdForEditor].color : ''
+      }
+    }
+  },
+  created: function() {
+    this.resetDataForEdit()
+  },
+  methods: {
+    resetDataForEdit() {
+      // 編集用のデータを設定値にする
+      this.editableTaskName = this.taskName
+      this.editableCategories = this.categories ? this.categories.slice(0, this.categories.length) : []
+      this.editableIsDone = this.isDone
+      this.editableTaskDate = this.taskDate
+      this.editableTaskDetail = this.taskDetail
+    },
+    closeDialog() {
+      this.dialog = false
+    },
+    createTask() {
+      // 親コンポーネントに変更後のタスクオブジェクトを伝える
+      const createdTaskData = {
+        'id': this.taskId,
+        'name': this.editableTaskName,
+        'categories': this.editableCategories,
+        'isDone': this.editableIsDone,
+        'date': this.editableTaskDate,
+        'detail': this.editableTaskDetail
+      }
+      this.$emit('task:created', createdTaskData)
+      this.snackbarCreate = true
+      this.closeDialog()
+    },
+    openCategorySelector() {
+      this.categorySelector = true
+    },
+    closeCategorySelector() {
+      this.categorySelector = false
+    },
+    openCategoryEditor(categoryId) {
+      this.categoryIdForEditor = categoryId
+      this.categoryEditor = true
+    },
+    closeCategoryEditor() {
+      this.categoryEditor = false
+    },
+    deleteCategory(categoryId) {
+      // 編集可能なカテゴリの配列から引数の配列を削除
+      const categoryIndex = this.editableCategories.indexOf(categoryId)
+      this.$delete(this.editableCategories, categoryIndex)
+      console.log('category deleted')
+    },
+    updateCategoryData(updatedCategoryData) {
+      this.$emit('category:updated', updatedCategoryData)
+    },
+    addCategoryData(newCategoryData) {
+      this.$emit('category:created', newCategoryData)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.task-info {
+  &-data {
+    font-size: 1.125rem;
+  }
+
+  &-detail {
+    white-space: pre-wrap;
+    line-height: 1.5;
+  }
+}
+</style>

--- a/frontend/components/Task/Create.vue
+++ b/frontend/components/Task/Create.vue
@@ -1,12 +1,12 @@
 <!--
 activator:         ダイアログを起動させるためのエレメントをセレクタで指定。例):activator="#activator"
-taskId:            表示するタスクのID
 taskName:          表示するタスクのタイトル
 taskDate:          表示するタスクの最新の表示日
 taskDetail:        表示するタスクの内容
 categories:        表示するタスクに設定されたカテゴリの配列
 isDone:            表示するタスクが完了しているかどうか
 categoryData:      カテゴリの情報をもつ配列
+tasks:             全てのタスクのデータ
 @task:created:     タスクの保存ボタンを押した時に発火するイベント
                    タスクオブジェクトを返す
                    {
@@ -202,17 +202,13 @@ export default {
       type: String,
       required: true
     },
-    taskId: {
-      type: String,
-      required: true
-    },
     taskName: {
       type: String,
       default: ""
     },
     categories: {
       type: Array,
-      default: []
+      default: () => []
     },
     isDone: {
       type: Boolean,
@@ -229,6 +225,10 @@ export default {
     categoryData: {
       type: Object
     },
+    tasks: {
+      type: Array,
+      required: true
+    }
   },
   data() {
     return {
@@ -274,6 +274,22 @@ export default {
       get() {
         return this.categoryIdForEditor ? this.categoryData[this.categoryIdForEditor].color : ''
       }
+    },
+    newTaskId: function() {
+      let newTaskId = ""
+      const min = 1000
+      const max = 9999
+      let ok = false
+      while (!ok) {
+        // 新規タスクIDを生成
+        newTaskId = String(Math.floor( Math.random() * (max + 1 - min) ) + min)
+        // 既存のタスクのIDと被っていなければ決定
+        if (!this.tasks.find(task => task.id == newTaskId)) {
+          ok = true
+        }
+      }
+
+      return newTaskId
     }
   },
   created: function() {
@@ -294,7 +310,7 @@ export default {
     createTask() {
       // 親コンポーネントに変更後のタスクオブジェクトを伝える
       const createdTaskData = {
-        'id': this.taskId,
+        'id': this.newTaskId,
         'name': this.editableTaskName,
         'categories': this.editableCategories,
         'isDone': this.editableIsDone,
@@ -303,6 +319,7 @@ export default {
       }
       this.$emit('task:created', createdTaskData)
       this.snackbarCreate = true
+      this.resetDataForEdit()
       this.closeDialog()
     },
     openCategorySelector() {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="page-home">
+    <TaskAddFAB
+      :categoryData="testCategoryData"
+      @task:created="addTaskData($event)"
+      @category:updated="updateCategoryData($event)"
+      @category:created="addCategoryData($event)"
+    />
     <Tab
       leftName="未完了"
       rightName="完了"
@@ -57,6 +63,12 @@ export default {
     updateHeader() {
       // タイトルとして使いたい情報を渡す
       this.$nuxt.$emit('updateHeader', this.header.title)
+    },
+    addTaskData(newTaskData) {
+      this.testTasks.splice(0, 0, newTaskData)
+      console.log('add new task')
+      console.log('new:')
+      console.log(this.testTasks)
     },
     deleteTaskData(taskId) {
       // 仮

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -2,6 +2,7 @@
   <div class="page-home">
     <TaskAddFAB
       :categoryData="testCategoryData"
+      :tasks="testTasks"
       @task:created="addTaskData($event)"
       @category:updated="updateCategoryData($event)"
       @category:created="addCategoryData($event)"

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -1,13 +1,22 @@
 <template>
-  <TaskListGroupByDate
-    :shownTasks="0"
-    :tasks="testTasks"
-    :categoryData="testCategoryData"
-    @task:deleted="deleteTaskData($event)"
-    @task:updated="updateTaskData($event)"
-    @category:updated="updateCategoryData($event)"
-    @category:created="addCategoryData($event)"
-  />
+  <div class="page-tasks">
+    <TaskListGroupByDate
+      :shownTasks="0"
+      :tasks="testTasks"
+      :categoryData="testCategoryData"
+      @task:deleted="deleteTaskData($event)"
+      @task:updated="updateTaskData($event)"
+      @category:updated="updateCategoryData($event)"
+      @category:created="addCategoryData($event)"
+    />
+
+    <TaskAddFAB
+      :categoryData="testCategoryData"
+      @task:created="addTaskData($event)"
+      @category:updated="updateCategoryData($event)"
+      @category:created="addCategoryData($event)"
+    />
+  </div>
 </template>
 
 <script>
@@ -46,6 +55,12 @@ export default {
     updateHeader() {
       // タイトルとして使いたい情報を渡す
       this.$nuxt.$emit('updateHeader', this.header.title)
+    },
+    addTaskData(newTaskData) {
+      this.testTasks.splice(0, 0, newTaskData)
+      console.log('add new task')
+      console.log('new:')
+      console.log(this.testTasks)
     },
     deleteTaskData(taskId) {
       // 仮

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -12,6 +12,7 @@
 
     <TaskAddFAB
       :categoryData="testCategoryData"
+      :tasks="testTasks"
       @task:created="addTaskData($event)"
       @category:updated="updateCategoryData($event)"
       @category:created="addCategoryData($event)"


### PR DESCRIPTION
よろしくお願いします。

## 変更点
### 新規追加
- タスク新規作成ダイアログ(frontend/components/Task/Create.vue)
- タスク追加ボタン(frontend/components/Task/AddFAB.vue)

FAB = Floating Action Button
タスクの追加ボタンはいったん位置は変えられない仕様にしています。
現時点では一番最後のタスクの完了ボタンと被ってしまい、完了ボタンが押せない不具合がありますが、後ほど別ブランチでの修正を検討しています。

### 変更
各ページにタスク追加ボタンを追加、タスクを新規追加するための関数を作成しました。
関数内での処理は、データの扱い方の変更に伴い、後ほど別ブランチでの修正を検討しています。
- ホーム
- タスク一覧