### PR TITLE
CORSエラーを修正

### DIFF
--- a/backend/project/settings.py
+++ b/backend/project/settings.py
@@ -134,3 +134,7 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CORS_ORIGIN_WHITELIST = (
+ 'http://localhost:3000',
+)

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -41,7 +41,9 @@ export default {
   ],
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
-  axios: {},
+  axios: {
+    baseURL: 'http://localhost:8000/',
+  },
 
   // PWA module configuration: https://go.nuxtjs.dev/pwa
   pwa: {


### PR DESCRIPTION
CORSエラーを修正しました。

### 修正箇所
- CORS_ORIGIN_WHITELISTを追加
- baseURLを追加

### axiosの使い方
```
this.$axios.get('/api/ ~~uri~~ /')
```

- baseURLに "http://localhost:8000/" を指定したので "/api/" からuriを入力してください。
- uriの最後は "/" をつけてください。