### PR TITLE
タスクやカテゴリのデータと処理をVuexに移行

### DIFF
--- a/frontend/components/Calendar/Month.vue
+++ b/frontend/components/Calendar/Month.vue
@@ -33,7 +33,7 @@ export default {
   props: {
     date: {
       type: String,
-      default: new Date().toISOString().substr(0, 7),
+      default: new Date().toLocaleDateString().substr(0, 7).replace('/', '-'),
     },
   },
   data() {

--- a/frontend/components/Task/AddFAB.vue
+++ b/frontend/components/Task/AddFAB.vue
@@ -36,7 +36,6 @@ export default {
   props: {
     categoryData: {
       type: Object,
-      required: true,
     },
   },
   data() {

--- a/frontend/components/Task/Info.vue
+++ b/frontend/components/Task/Info.vue
@@ -366,7 +366,8 @@ export default {
         'title': this.editableTaskTitle,
         'category': this.editableCategories,
         'next_display_date': this.editableTaskDate,
-        'detail': this.editableTaskDetail
+        'detail': this.editableTaskDetail,
+        'url': null,
       }
       this.$emit('task:updated', updatedTaskData)
       this.editable = false

--- a/frontend/components/UserForm/SingleDate.vue
+++ b/frontend/components/UserForm/SingleDate.vue
@@ -27,7 +27,7 @@ placeholder:  入力フォームに表示するプレイスホルダー
           full-width
           scrollable
           locale="jp-ja"
-          :min="new Date().toLocaleDateString().split('/').join('-')"
+          :min="new Date().toLocaleDateString().replaceAll('/', '-')"
           :day-format="(date) => new Date(date).getDate()"
           color="primary"
         >

--- a/frontend/components/UserForm/SingleDate.vue
+++ b/frontend/components/UserForm/SingleDate.vue
@@ -27,7 +27,7 @@ placeholder:  入力フォームに表示するプレイスホルダー
           full-width
           scrollable
           locale="jp-ja"
-          :min="new Date().toISOString().substr(0, 10)"
+          :min="new Date().toLocaleDateString().split('/').join('-')"
           :day-format="(date) => new Date(date).getDate()"
           color="primary"
         >

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -28,6 +28,7 @@ export default {
   plugins: [
     '~/plugins/dexie.js',
     '~/plugins/network.js',
+    '~/plugins/setup.js',
   ],
 
   // Auto import components: https://go.nuxtjs.dev/config-components

--- a/frontend/pages/calendar/index.vue
+++ b/frontend/pages/calendar/index.vue
@@ -74,7 +74,7 @@ export default {
       header: {
         title: 'カレンダー',
       },
-      date: new Date().toISOString().substr(0, 10),
+      date: new Date().toLocaleDateString().replaceAll('/', '-'),
       dialog: false,
       task: {
         title: '',

--- a/frontend/pages/calendar/index.vue
+++ b/frontend/pages/calendar/index.vue
@@ -82,14 +82,18 @@ export default {
       },
       setItem: [],
       taskItems: [],
-      tasks: [],
-      taskData: null,
       categoryData: null,
       snackbar: false,
       errorMessage: null,
     }
   },
   computed: {
+    tasks() {
+      return this.$store.getters.tasks
+    },
+    taskData() {
+      return this.$store.getters.taskData
+    },
     // 日付をフォーマット
     formatDate() {
       const dt = new Date(this.date)
@@ -100,7 +104,9 @@ export default {
   },
   mounted() {
     this.updateHeader()
-    this.fetchTasks()
+    // this.fetchTasks()
+    this.$store.dispatch('getTaskDataFromIDB')
+    .then(taskData => this.taskItems = this.dedupe(taskData))
     this.fetchCategoryData()
   },
   methods: {

--- a/frontend/pages/calendar/index.vue
+++ b/frontend/pages/calendar/index.vue
@@ -270,12 +270,6 @@ export default {
       .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     deleteTaskData(taskId) {
-      // this.$store.dispatch('deleteTask', taskId)
-      // .then(() => {
-      //   this.loadingTask = true
-      //   this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
-      //   .then(() => this.loadingTask = false)
-      // })
       this.$store.dispatch('deleteTask', taskId)
       .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
@@ -283,53 +277,11 @@ export default {
       const taskId = updatedData.id
       delete updatedData.id
 
-      // IDBで更新する処理
-      const promiseUpdateTaskOnIDB = this.$db.task.update(taskId, updatedData)
-      .then(() => {
-        console.log('タスク更新(IDB) >> 成功')
-      })
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信する処理
-        const promiseUpdateTaskOnServer = this.$axios.put('/api/task/'+String(taskId)+'/', updatedData)
-        .then(() => {
-          console.log('タスク更新(API) >> 成功')
+      this.$store.dispatch('updateTask', {
+          taskId: taskId,
+          data: updatedData,
         })
-
-        promiseUpdateTaskOnIDB
-        .then(() => promiseUpdateTaskOnServer)
-        .catch(e => {
-          console.log('タスク更新(Online) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-
-      } else {
-        // オフラインの場合
-        promiseUpdateTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'update',
-            'data': updatedData,
-          })
-        })
-        .catch(e => {
-          console.log('タスク更新(Offline) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          this.errorMessage = 'タスク更新の同期に失敗しました。オンラインに復帰後同期します。'
-
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-      }
+      .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     doneTask(data) {
       const taskDateId = data.taskDateId

--- a/frontend/pages/calendar/index.vue
+++ b/frontend/pages/calendar/index.vue
@@ -211,87 +211,8 @@ export default {
       .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
     addCategoryData(newCategoryData) {
-      // カテゴリデータを追加
-      // サーバーに送信
-      const sendData = {
-        'category_name': newCategoryData.name,
-        'color_code': newCategoryData.color,
-      }
-
-      // IDBに追加する処理
-      const promiseAddCategoryToIDB = categoryData => {
-        const data = {'id': categoryData.id, ...newCategoryData}
-
-        return this.$db.category.add(data)
-        .then(() => {
-          console.log('カテゴリ新規作成(IDB) >> 成功')
-        })
-      }
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに追加する処理
-        const promiseAddCategoryToServer = this.$axios.post('/api/category/', sendData)
-        .then((response) => {
-          console.log('カテゴリ新規作成(API) >> 成功')
-          return response.data
-        })
-
-        promiseAddCategoryToServer
-        .then(categoryData => promiseAddCategoryToIDB(categoryData))
-        .then(() => {
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Online) >> 失敗')
-          console.error(e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        const newId = this.makeTmpId('category')
-        promiseAddCategoryToIDB({'id': newId})
-        .then(() => {
-          // offline_categoryに登録
-          return this.$db.offline_category.add({
-            'category_id': newId,
-            'type': 'create',
-            'data': sendData,
-          })
-        })
-        .then(() => {
-          this.errorMessage = 'カテゴリ新規作成の同期に失敗しました。オンラインに復帰後同期します。'
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Offline) >> 失敗')
-          console.error(e.message)
-        })
-      }
-    },
-    makeTmpId(type) {
-      // 【追加系api通信が新規IDを返すようになるまで使用】仮の新規IDを生成
-      let existIds = []
-      if (type == 'category') {
-        existIds = Object.keys(this.categoryData).map(id => Number(id))
-      } else if (type == 'task') {
-        existIds = this.tasks.map(task => task.task_id)
-      } else {
-        return
-      }
-
-      // 存在しているIDの最大値＋1
-      let maxId = null
-      if (existIds[0]) {
-        maxId = existIds.reduce((a, b) => {
-          return Math.max(a, b)
-        })
-        return maxId + 1
-      } else {
-        return 1
-      }
+      this.$store.dispatch('addCategoryData', newCategoryData)
+      .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
     // 追加時の処理
     onAdd(date) {

--- a/frontend/pages/calendar/index.vue
+++ b/frontend/pages/calendar/index.vue
@@ -270,63 +270,14 @@ export default {
       .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     deleteTaskData(taskId) {
-      // IDBから削除
-      const promiseDeleteTaskOnIDB = this.$db.task.delete(taskId)
-      .then(() => {
-        console.log('タスク削除(IDB)1 >> 成功')
-
-        return this.$db.task_date
-        .where('task_id')
-        .equals(taskId)
-        .delete().then(() => {
-          console.log('タスク削除(IDB)2 >> 成功')
-        })
-      })
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信(オンラインの場合)
-        const promiseDeleteTaskOnServer = this.$axios.delete('/api/task/'+String(taskId)+'/')
-        .then(() => {
-          console.log('タスク削除(API) >> 成功')
-        })
-
-        promiseDeleteTaskOnIDB
-        .then(() => promiseDeleteTaskOnServer)
-        .catch(e => {
-          console.log('タスク削除(Online) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          // 削除を通知
-          this.snackbarDelete = true
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-
-      } else {
-        // オフラインの場合
-        promiseDeleteTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'delete',
-            'data': null,
-          })
-        })
-        .catch(e => {
-          console.log('タスク削除(Offline) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          this.errorMessage = 'タスク削除の同期に失敗しました。オンラインに復帰後同期します。'
-          // 削除を通知
-          this.snackbarDelete = true
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-      }
+      // this.$store.dispatch('deleteTask', taskId)
+      // .then(() => {
+      //   this.loadingTask = true
+      //   this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+      //   .then(() => this.loadingTask = false)
+      // })
+      this.$store.dispatch('deleteTask', taskId)
+      .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     updateTaskData(updatedData) {
       const taskId = updatedData.id

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -229,57 +229,71 @@ export default {
         .then(() => this.loadingTask = false)
       })
     },
+    // updateTaskData(updatedData) {
+    //   const taskId = updatedData.id
+    //   delete updatedData.id
+
+    //   // IDBで更新する処理
+    //   const promiseUpdateTaskOnIDB = this.$db.task.update(taskId, updatedData)
+    //   .then(() => {
+    //     console.log('タスク更新(IDB) >> 成功')
+    //   })
+      
+    //   if (this.$store.getters.isOnline) {
+    //     // オンラインの場合
+    //     // サーバーに送信する処理
+    //     const promiseUpdateTaskOnServer = this.$axios.put('/api/task/'+String(taskId)+'/', updatedData)
+    //     .then(() => {
+    //       console.log('タスク更新(API) >> 成功')
+    //     })
+
+    //     promiseUpdateTaskOnIDB
+    //     .then(() => promiseUpdateTaskOnServer)
+    //     .catch(e => {
+    //       console.log('タスク更新(Online) >> 失敗')
+    //       console.error(e.message)
+    //     })
+    //     .then(() => {
+    //       // タスクデータの再読み込み
+    //       this.getTasksFromDB()
+    //     })
+
+    //   } else {
+    //     // オフラインの場合
+    //     promiseUpdateTaskOnIDB
+    //     .then(() => {
+    //       // offline_taskに登録
+    //       return this.$db.offline_task.add({
+    //         'task_id': taskId,
+    //         'type': 'update',
+    //         'data': updatedData,
+    //       })
+    //     })
+    //     .catch(e => {
+    //       console.log('タスク更新(Offline) >> 失敗')
+    //       console.error(e.message)
+    //     })
+    //     .then(() => {
+    //       this.errorMessage = 'タスク更新の同期に失敗しました。オンラインに復帰後同期します。'
+
+    //       // タスクデータの再読み込み
+    //       this.getTasksFromDB()
+    //     })
+    //   }
+    // },
     updateTaskData(updatedData) {
       const taskId = updatedData.id
       delete updatedData.id
 
-      // IDBで更新する処理
-      const promiseUpdateTaskOnIDB = this.$db.task.update(taskId, updatedData)
+      this.$store.dispatch('updateTask', {
+          taskId: taskId,
+          data: updatedData,
+        })
       .then(() => {
-        console.log('タスク更新(IDB) >> 成功')
+        this.loadingTask = true
+        this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+        .then(() => this.loadingTask = false)
       })
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信する処理
-        const promiseUpdateTaskOnServer = this.$axios.put('/api/task/'+String(taskId)+'/', updatedData)
-        .then(() => {
-          console.log('タスク更新(API) >> 成功')
-        })
-
-        promiseUpdateTaskOnIDB
-        .then(() => promiseUpdateTaskOnServer)
-        .catch(e => {
-          console.log('タスク更新(Online) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-
-      } else {
-        // オフラインの場合
-        promiseUpdateTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'update',
-            'data': updatedData,
-          })
-        })
-        .catch(e => {
-          console.log('タスク更新(Offline) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          this.errorMessage = 'タスク更新の同期に失敗しました。オンラインに復帰後同期します。'
-
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-      }
     },
     doneTask(data) {
       const taskDateId = data.taskDateId

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -46,17 +46,23 @@ export default {
         title: 'ホーム'
       },
       activeTab: 1,
-      tasks: null,
-      taskData: null,
       loadingTask: false,
       categoryData: null,
       snackbarDelete: false,
       errorMessage: null,
     }
   },
+  computed: {
+    tasks() {
+      return this.$store.getters.tasks
+    },
+    taskData() {
+      return this.$store.getters.taskData
+    },
+  },
   mounted() {
     this.updateHeader()
-    this.fetchTasks()
+    // this.fetchTasks()
     this.fetchCategoryData()
   },
   methods: {

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -215,66 +215,19 @@ export default {
     },
     addTaskData(newTaskData) {
       this.$store.dispatch('addTask', newTaskData)
-      .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
+      .then(() => {
+        this.loadingTask = true
+        this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+        .then(() => this.loadingTask = false)
+      })
     },
     deleteTaskData(taskId) {
-      // IDBから削除
-      const promiseDeleteTaskOnIDB = this.$db.task.delete(taskId)
+      this.$store.dispatch('deleteTask', taskId)
       .then(() => {
-        console.log('タスク削除(IDB)1 >> 成功')
-
-        return this.$db.task_date
-        .where('task_id')
-        .equals(taskId)
-        .delete().then(() => {
-          console.log('タスク削除(IDB)2 >> 成功')
-        })
+        this.loadingTask = true
+        this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+        .then(() => this.loadingTask = false)
       })
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信(オンラインの場合)
-        const promiseDeleteTaskOnServer = this.$axios.delete('/api/task/'+String(taskId)+'/')
-        .then(() => {
-          console.log('タスク削除(API) >> 成功')
-        })
-
-        promiseDeleteTaskOnIDB
-        .then(() => promiseDeleteTaskOnServer)
-        .catch(e => {
-          console.log('タスク削除(Online) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          // 削除を通知
-          this.snackbarDelete = true
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-
-      } else {
-        // オフラインの場合
-        promiseDeleteTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'delete',
-            'data': null,
-          })
-        })
-        .catch(e => {
-          console.log('タスク削除(Offline) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          this.errorMessage = 'タスク削除の同期に失敗しました。オンラインに復帰後同期します。'
-          // 削除を通知
-          this.snackbarDelete = true
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-      }
     },
     updateTaskData(updatedData) {
       const taskId = updatedData.id

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -129,88 +129,9 @@ export default {
       .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
     addCategoryData(newCategoryData) {
-      // カテゴリデータを追加
-      // サーバーに送信
-      const sendData = {
-        'category_name': newCategoryData.name,
-        'color_code': newCategoryData.color,
-      }
-
-      // IDBに追加する処理
-      const promiseAddCategoryToIDB = categoryData => {
-        const data = {'id': categoryData.id, ...newCategoryData}
-
-        return this.$db.category.add(data)
-        .then(() => {
-          console.log('カテゴリ新規作成(IDB) >> 成功')
-        })
-      }
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに追加する処理
-        const promiseAddCategoryToServer = this.$axios.post('/api/category/', sendData)
-        .then((response) => {
-          console.log('カテゴリ新規作成(API) >> 成功')
-          return response.data
-        })
-
-        promiseAddCategoryToServer
-        .then(categoryData => promiseAddCategoryToIDB(categoryData))
-        .then(() => {
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Online) >> 失敗')
-          console.error(e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        const newId = this.makeTmpId('category')
-        promiseAddCategoryToIDB({'id': newId})
-        .then(() => {
-          // offline_categoryに登録
-          return this.$db.offline_category.add({
-            'category_id': newId,
-            'type': 'create',
-            'data': sendData,
-          })
-        })
-        .then(() => {
-          this.errorMessage = 'カテゴリ新規作成の同期に失敗しました。オンラインに復帰後同期します。'
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Offline) >> 失敗')
-          console.error(e.message)
-        })
-      }
+      this.$store.dispatch('addCategoryData', newCategoryData)
+      .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
-    makeTmpId(type) {
-      // 【追加系api通信が新規IDを返すようになるまで使用】仮の新規IDを生成
-      let existIds = []
-      if (type == 'category') {
-        existIds = Object.keys(this.categoryData).map(id => Number(id))
-      } else if (type == 'task') {
-        existIds = this.tasks.map(task => task.task_id)
-      } else {
-        return
-      }
-
-      // 存在しているIDの最大値＋1
-      let maxId = null
-      if (existIds[0]) {
-        maxId = existIds.reduce((a, b) => {
-          return Math.max(a, b)
-        })
-        return maxId + 1
-      } else {
-        return 1
-      }
-    }
   }
 }
 </script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -214,57 +214,8 @@ export default {
       }
     },
     addTaskData(newTaskData) {
-      // IDBに登録する
-      const promiseAddTaskToIDB = taskData => {
-        return this.$db.task.add(taskData).then(() => {
-          console.log('タスク追加(IDB) >> 成功')
-        }).catch((e) => {
-          console.log('タスク追加(IDB) >> 失敗')
-          console.error(e.message)
-        }).then(() => {
-          // データを整形
-          let newData = {
-            'task_id': taskData.id,
-            'date': taskData.next_display_date,
-            'is_done': false,
-          }
-          return this.$db.task_date.add(newData)
-        })
-      }
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに追加する
-        const promiseAddTaskToServer = this.$axios.post('/api/task/', newTaskData)
-        .then(response => response.data)
-        .then(taskData => {
-          console.log('タスク追加(API) >> 成功')
-          return taskData
-        }).catch((e) => {
-          console.log('タスク追加(API) >> 失敗')
-          console.error(e.message)
-        })
-
-        // オンライン時はデータを同期して保存
-        promiseAddTaskToServer
-        .then((taskData) => promiseAddTaskToIDB(taskData))
-        .then(() => this.getTasksFromDB())
-      } else {
-        // オフライン時は仮のIDで保存し、offline_taskテーブルに追加
-        const taskId = this.makeTmpId('task')
-        const saveData = {'id': taskId, ...newTaskData}
-        promiseAddTaskToIDB(saveData)
-        .then(() => {
-          this.errorMessage = 'タスク追加の同期に失敗しました。オンラインに復帰後同期します。'
-
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'create',
-            'data': newTaskData,
-          })
-        })
-        .then(() => this.getTasksFromDB())
-      }
+      this.$store.dispatch('addTask', newTaskData)
+      .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     deleteTaskData(taskId) {
       // IDBから削除

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="page-home">
     <TaskAddFAB
-      v-if="categoryData"
       :categoryData="categoryData"
       @task:created="addTaskData($event)"
       @category:updated="updateCategoryData($event)"

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -47,7 +47,6 @@ export default {
       },
       activeTab: 1,
       loadingTask: false,
-      categoryData: null,
       snackbarDelete: false,
       errorMessage: null,
     }
@@ -59,159 +58,17 @@ export default {
     taskData() {
       return this.$store.getters.taskData
     },
+    categoryData() {
+      return this.$store.getters.categoryData
+    }
   },
   mounted() {
     this.updateHeader()
-    // this.fetchTasks()
-    this.fetchCategoryData()
   },
   methods: {
-    getTasksFromDB() {
-      console.log('getTasksFromDB()')
-      this.loadingTask = true
-
-      // IDBからタスクを取得
-      const promiseTaskData = this.$db.task.toArray()
-      .then((tasks) => {
-        console.log('Got tasks from table: task')
-
-        // データを整形して保持
-        let newData = {}
-        tasks.forEach((task) => {
-          const taskId = task.id
-          delete task.id
-          newData[taskId] = task
-        })
-        // タスクデータの適用
-        this.taskData = newData
-      })
-      // タスクリストを取得
-      const promiseTaskDate = this.$db.task_date.toArray()
-      .then(tasks => {
-        console.log('Got tasks from table: task_date.')
-        this.tasks = tasks
-      })
-
-      Promise.all([promiseTaskData, promiseTaskDate])
-      .then(() => {
-        this.loadingTask = false
-      })
-    },
-    getCategoryDataFromDB() {
-      console.log('getCategoryDataFromDB()')
-
-      // IDBからカテゴリを取得
-      this.$db.category.toArray()
-      .then((categoryData) => {
-        
-        // データを整形して保持
-        let newData = {}
-        categoryData.forEach((category) => {
-          newData[category.id] = {'name': category.name, 'color': category.color}
-        })
-        this.categoryData = newData
-        console.log('categoryData >> 取得成功')
-      })
-      .catch((e) => {
-        console.log('categoryData >> 取得失敗')
-        console.error(e.message)
-      })
-    },
     updateHeader() {
       // タイトルとして使いたい情報を渡す
       this.$nuxt.$emit('updateHeader', this.header.title)
-    },
-    fetchTasks() {
-      console.log('fetchTasks()')
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーから未完了のタスクデータを取得し、保存する
-        const promiseTask = this.$axios.get('/api/task/').then(response => response.data)
-        .then(tasks => {
-          console.log('promiseTask１')
-          console.log('タスク取得(API) >> 成功')
-          // IDBからタスクを削除
-          return this.$db.task.clear()
-          .then(() => {
-            console.log('promiseTask２')
-            // タスクデータをIDBに保存
-            return this.$db.task.bulkAdd(tasks).then(() => {
-              console.log('promiseTask３')
-              console.log('タスク保存(IDB) >> 成功')
-              return tasks
-            }).catch((e) => {
-              console.log('タスク保存(IDB) >> 失敗')
-              console.error(e.message)
-            })
-          })
-          .catch((e) => {
-            console.log('タスク(IDB)削除 >> 失敗')
-          })
-        })
-
-        // サーバーから完了済のタスクデータを取得する
-        const promiseHistory = this.$axios.get('/api/history/')
-        .then(response => response.data)
-        .then(history => {
-          console.log('promiseHistory１')
-          console.log('ヒストリー取得(API) >> 成功')
-          return history
-        })
-
-        // task_dateを削除する
-        const promiseClearTaskDate = this.$db.task_date.clear()
-
-        // task_dateにタスクリストを追加する
-        const promiseAddTaskDate = (tasks, history) => {
-          console.log('promiseAddTaskDate１')
-          // データを整形
-          let newTaskData = []
-          tasks.forEach(task => {
-            const taskData = {
-              'task_id': task.id,
-              'date': task.next_display_date,
-              'is_done': false,
-            }
-            newTaskData.push(taskData)
-          })
-          history.forEach((task) => {
-            const taskData = {
-              'date': task.completed_date,
-              'is_done': true,
-              'feedback': task.feedback,
-              'task_id': task.task_id,
-            }
-            newTaskData.push(taskData)
-          })
-          // IDBに保存
-          return this.$db.task_date.bulkAdd(newTaskData).then(() => {
-            console.log('タスクリスト保存(IDB) >> 成功')
-          }).catch(e => {
-            console.log('タスクリスト保存(IDB) >> 失敗')
-            console.error(e.message)
-          })
-        }
-
-        // オンラインならサーバーからデータを取得・適用
-        Promise.all([promiseTask, promiseHistory])
-        .then(arrays => {
-          return promiseClearTaskDate
-          .then(() => {
-            console.log('promiseClearTaskDate１')
-            return arrays
-          })
-        })
-        .then(arrays => promiseAddTaskDate(arrays[0], arrays[1]))
-        .then(() => this.getTasksFromDB())
-        .catch(e => {
-          console.error('fetchTaskData Error: '+e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        this.errorMessage = 'データの取得に失敗しました。ローカルデータを表示します。'
-        this.getTasksFromDB()
-      }
     },
     addTaskData(newTaskData) {
       this.$store.dispatch('addTask', newTaskData)

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -180,88 +180,9 @@ export default {
       .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
     addCategoryData(newCategoryData) {
-      // カテゴリデータを追加
-      // サーバーに送信
-      const sendData = {
-        'category_name': newCategoryData.name,
-        'color_code': newCategoryData.color,
-      }
-
-      // IDBに追加する処理
-      const promiseAddCategoryToIDB = categoryData => {
-        const data = {'id': categoryData.id, ...newCategoryData}
-
-        return this.$db.category.add(data)
-        .then(() => {
-          console.log('カテゴリ新規作成(IDB) >> 成功')
-        })
-      }
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに追加する処理
-        const promiseAddCategoryToServer = this.$axios.post('/api/category/', sendData)
-        .then((response) => {
-          console.log('カテゴリ新規作成(API) >> 成功')
-          return response.data
-        })
-
-        promiseAddCategoryToServer
-        .then(categoryData => promiseAddCategoryToIDB(categoryData))
-        .then(() => {
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Online) >> 失敗')
-          console.error(e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        const newId = this.makeTmpId('category')
-        promiseAddCategoryToIDB({'id': newId})
-        .then(() => {
-          // offline_categoryに登録
-          return this.$db.offline_category.add({
-            'category_id': newId,
-            'type': 'create',
-            'data': sendData,
-          })
-        })
-        .then(() => {
-          this.errorMessage = 'カテゴリ新規作成の同期に失敗しました。オンラインに復帰後同期します。'
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch((e) => {
-          console.log('カテゴリ新規作成(Offline) >> 失敗')
-          console.error(e.message)
-        })
-      }
+      this.$store.dispatch('addCategoryData', newCategoryData)
+      .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
-    makeTmpId(type) {
-      // 【追加系api通信が新規IDを返すようになるまで使用】仮の新規IDを生成
-      let existIds = []
-      if (type == 'category') {
-        existIds = Object.keys(this.categoryData).map(id => Number(id))
-      } else if (type == 'task') {
-        existIds = this.tasks.map(task => task.task_id)
-      } else {
-        return
-      }
-
-      // 存在しているIDの最大値＋1
-      let maxId = null
-      if (existIds[0]) {
-        maxId = existIds.reduce((a, b) => {
-          return Math.max(a, b)
-        })
-        return maxId + 1
-      } else {
-        return 1
-      }
-    }
   }
 }
 </script>

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -49,17 +49,23 @@ export default {
         title: 'タスク一覧'
       },
       activeTab: 1,
-      tasks: null,
-      taskData: null,
       loadingTask: false,
       categoryData: null,
       snackbarDelete: false,
       errorMessage: null,
     }
   },
+  computed: {
+    tasks() {
+      return this.$store.getters.tasks
+    },
+    taskData() {
+      return this.$store.getters.taskData
+    },
+  },
   mounted() {
     this.updateHeader()
-    this.fetchTasks()
+    // this.fetchTasks()
     this.fetchCategoryData()
   },
   methods: {

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -50,7 +50,6 @@ export default {
       },
       activeTab: 1,
       loadingTask: false,
-      categoryData: null,
       snackbarDelete: false,
       errorMessage: null,
     }
@@ -62,159 +61,17 @@ export default {
     taskData() {
       return this.$store.getters.taskData
     },
+    categoryData() {
+      return this.$store.getters.categoryData
+    }
   },
   mounted() {
     this.updateHeader()
-    // this.fetchTasks()
-    this.fetchCategoryData()
   },
   methods: {
-    getTasksFromDB() {
-      console.log('getTasksFromDB()')
-      this.loadingTask = true
-
-      // IDBからタスクを取得
-      const promiseTaskData = this.$db.task.toArray()
-      .then((tasks) => {
-        console.log('Got tasks from table: task')
-
-        // データを整形して保持
-        let newData = {}
-        tasks.forEach((task) => {
-          const taskId = task.id
-          delete task.id
-          newData[taskId] = task
-        })
-        // タスクデータの適用
-        this.taskData = newData
-      })
-      // タスクリストを取得
-      const promiseTaskDate = this.$db.task_date.toArray()
-      .then(tasks => {
-        console.log('Got tasks from table: task_date.')
-        this.tasks = tasks
-      })
-
-      Promise.all([promiseTaskData, promiseTaskDate])
-      .then(() => {
-        this.loadingTask = false
-      })
-    },
-    getCategoryDataFromDB() {
-      console.log('getCategoryDataFromDB()')
-
-      // IDBからカテゴリを取得
-      this.$db.category.toArray()
-      .then((categoryData) => {
-        
-        // データを整形して保持
-        let newData = {}
-        categoryData.forEach((category) => {
-          newData[category.id] = {'name': category.name, 'color': category.color}
-        })
-        this.categoryData = newData
-        console.log('categoryData >> 取得成功')
-      })
-      .catch((e) => {
-        console.log('categoryData >> 取得失敗')
-        console.error(e.message)
-      })
-    },
     updateHeader() {
       // タイトルとして使いたい情報を渡す
       this.$nuxt.$emit('updateHeader', this.header.title)
-    },
-    fetchTasks() {
-      console.log('fetchTasks()')
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーから未完了のタスクデータを取得し、保存する
-        const promiseTask = this.$axios.get('/api/task/').then(response => response.data)
-        .then(tasks => {
-          console.log('promiseTask１')
-          console.log('タスク取得(API) >> 成功')
-          // IDBからタスクを削除
-          return this.$db.task.clear()
-          .then(() => {
-            console.log('promiseTask２')
-            // タスクデータをIDBに保存
-            return this.$db.task.bulkAdd(tasks).then(() => {
-              console.log('promiseTask３')
-              console.log('タスク保存(IDB) >> 成功')
-              return tasks
-            }).catch((e) => {
-              console.log('タスク保存(IDB) >> 失敗')
-              console.error(e.message)
-            })
-          })
-          .catch((e) => {
-            console.log('タスク(IDB)削除 >> 失敗')
-          })
-        })
-
-        // サーバーから完了済のタスクデータを取得する
-        const promiseHistory = this.$axios.get('/api/history/')
-        .then(response => response.data)
-        .then(history => {
-          console.log('promiseHistory１')
-          console.log('ヒストリー取得(API) >> 成功')
-          return history
-        })
-
-        // task_dateを削除する
-        const promiseClearTaskDate = this.$db.task_date.clear()
-
-        // task_dateにタスクリストを追加する
-        const promiseAddTaskDate = (tasks, history) => {
-          console.log('promiseAddTaskDate１')
-          // データを整形
-          let newTaskData = []
-          tasks.forEach(task => {
-            const taskData = {
-              'task_id': task.id,
-              'date': task.next_display_date,
-              'is_done': false,
-            }
-            newTaskData.push(taskData)
-          })
-          history.forEach((task) => {
-            const taskData = {
-              'date': task.completed_date,
-              'is_done': true,
-              'feedback': task.feedback,
-              'task_id': task.task_id,
-            }
-            newTaskData.push(taskData)
-          })
-          // IDBに保存
-          return this.$db.task_date.bulkAdd(newTaskData).then(() => {
-            console.log('タスクリスト保存(IDB) >> 成功')
-          }).catch(e => {
-            console.log('タスクリスト保存(IDB) >> 失敗')
-            console.error(e.message)
-          })
-        }
-
-        // オンラインならサーバーからデータを取得・適用
-        Promise.all([promiseTask, promiseHistory])
-        .then(arrays => {
-          return promiseClearTaskDate
-          .then(() => {
-            console.log('promiseClearTaskDate１')
-            return arrays
-          })
-        })
-        .then(arrays => promiseAddTaskDate(arrays[0], arrays[1]))
-        .then(() => this.getTasksFromDB())
-        .catch(e => {
-          console.error('fetchTaskData Error: '+e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        this.errorMessage = 'データの取得に失敗しました。ローカルデータを表示します。'
-        this.getTasksFromDB()
-      }
     },
     addTaskData(newTaskData) {
       this.$store.dispatch('addTask', newTaskData)

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -217,57 +217,8 @@ export default {
       }
     },
     addTaskData(newTaskData) {
-      // IDBに登録する
-      const promiseAddTaskToIDB = taskData => {
-        return this.$db.task.add(taskData).then(() => {
-          console.log('タスク追加(IDB) >> 成功')
-        }).catch((e) => {
-          console.log('タスク追加(IDB) >> 失敗')
-          console.error(e.message)
-        }).then(() => {
-          // データを整形
-          let newData = {
-            'task_id': taskData.id,
-            'date': taskData.next_display_date,
-            'is_done': false,
-          }
-          return this.$db.task_date.add(newData)
-        })
-      }
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに追加する
-        const promiseAddTaskToServer = this.$axios.post('/api/task/', newTaskData)
-        .then(response => response.data)
-        .then(taskData => {
-          console.log('タスク追加(API) >> 成功')
-          return taskData
-        }).catch((e) => {
-          console.log('タスク追加(API) >> 失敗')
-          console.error(e.message)
-        })
-
-        // オンライン時はデータを同期して保存
-        promiseAddTaskToServer
-        .then((taskData) => promiseAddTaskToIDB(taskData))
-        .then(() => this.getTasksFromDB())
-      } else {
-        // オフライン時は仮のIDで保存し、offline_taskテーブルに追加
-        const taskId = this.makeTmpId('task')
-        const saveData = {'id': taskId, ...newTaskData}
-        promiseAddTaskToIDB(saveData)
-        .then(() => {
-          this.errorMessage = 'タスク追加の同期に失敗しました。オンラインに復帰後同期します。'
-
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'create',
-            'data': newTaskData,
-          })
-        })
-        .then(() => this.getTasksFromDB())
-      }
+      this.$store.dispatch('addTask', newTaskData)
+      .then(() => this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB'))
     },
     deleteTaskData(taskId) {
       // IDBから削除

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -173,57 +173,11 @@ export default {
       const targetId = updatedCategoryData.id
       delete updatedCategoryData.id
 
-      // 更新するデータ
-      const sendData = {
-        'category_name': updatedCategoryData.name,
-        'color_code': updatedCategoryData.color,
-      }
-
-      // IDBで更新する処理
-      const promiseUpdateCategoryOnIDB = this.$db.category.update(targetId, updatedCategoryData)
-      .then(() => {
-        console.log('カテゴリ更新(IDB) >> 成功')
+      this.$store.dispatch('updateCategoryData', {
+        categoryId: targetId,
+        data: updatedCategoryData,
       })
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信する処理
-        const promiseUpdateCategoryOnServer = this.$axios.put('/api/category/'+targetId+'/', sendData)
-        .then(() => {
-          console.log('カテゴリ更新(API) >> 成功')
-        })
-
-        Promise.all([promiseUpdateCategoryOnIDB, promiseUpdateCategoryOnServer])
-        .then(() => {
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch(e => {
-          console.log('カテゴリ更新(Online) >> 失敗')
-          console.error(e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        promiseUpdateCategoryOnIDB
-        .then(() => {
-          // offline_categoryに登録
-          return this.$db.offline_category.add({
-            'category_id': targetId,
-            'type': 'update',
-            'data': sendData,
-          })
-        })
-        .then(() => {
-          this.errorMessage = 'カテゴリ更新の同期に失敗しました。オンラインに復帰後同期します。'
-          // カテゴリデータの再読み込み
-          this.getCategoryDataFromDB()
-        })
-        .catch(e => {
-          console.log('カテゴリ更新(Offline) >> 失敗')
-          console.error(e.message)
-        })
-      }
+      .then(() => this.$store.dispatch('replaceCategoryStateWithCategoryOnIDBCategory'))
     },
     addCategoryData(newCategoryData) {
       // カテゴリデータを追加

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -236,53 +236,15 @@ export default {
       const taskId = updatedData.id
       delete updatedData.id
 
-      // IDBで更新する処理
-      const promiseUpdateTaskOnIDB = this.$db.task.update(taskId, updatedData)
+      this.$store.dispatch('updateTask', {
+          taskId: taskId,
+          data: updatedData,
+        })
       .then(() => {
-        console.log('タスク更新(IDB) >> 成功')
+        this.loadingTask = true
+        this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+        .then(() => this.loadingTask = false)
       })
-      
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // サーバーに送信する処理
-        const promiseUpdateTaskOnServer = this.$axios.put('/api/task/'+String(taskId)+'/', updatedData)
-        .then(() => {
-          console.log('タスク更新(API) >> 成功')
-        })
-
-        promiseUpdateTaskOnIDB
-        .then(() => promiseUpdateTaskOnServer)
-        .catch(e => {
-          console.log('タスク更新(Online) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-
-      } else {
-        // オフラインの場合
-        promiseUpdateTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'update',
-            'data': updatedData,
-          })
-        })
-        .catch(e => {
-          console.log('タスク更新(Offline) >> 失敗')
-          console.error(e.message)
-        })
-        .then(() => {
-          this.errorMessage = 'タスク更新の同期に失敗しました。オンラインに復帰後同期します。'
-
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-      }
     },
     doneTask(data) {
       const taskDateId = data.taskDateId

--- a/frontend/pages/tasks.vue
+++ b/frontend/pages/tasks.vue
@@ -252,60 +252,16 @@ export default {
 
       const taskId = this.tasks.find(task => task.id === taskDateId).task_id
 
-      // IDBを更新
-      const promiseDoneTaskOnIDB = this.$db.task_date.update(taskDateId, {
-        'is_done': true,
-        'feedback': taskFeedback,
+      this.$store.dispatch('completeTask', {
+        taskDateId: taskDateId,
+        taskId: taskId,
+        feedback: taskFeedback,
       })
       .then(() => {
-        console.log('タスク完了(IDB) >> 成功')
+        this.loadingTask = true
+        this.$store.dispatch('replaceAllTaskStateWithTasksFromIDB')
+        .then(() => this.loadingTask = false)
       })
-
-      if (this.$store.getters.isOnline) {
-        // オンラインの場合
-        // API処理
-        const promiseCompleteTask = this.$axios.put('/api/task-completed-task/'+String(taskId)+'/', {'feedback': taskFeedback})
-        const promiseAddHistory = this.$axios.post('/api/task-completed-history/', {'task_id': taskId, 'feedback': taskFeedback})
-
-        // サーバーに送信し、IDBにも保存
-        Promise.all([promiseCompleteTask, promiseAddHistory, promiseDoneTaskOnIDB])
-        .then(() => {
-          console.log('タスク完了(Online) >> 成功')
-          // タスクデータの再取得・読み込み
-          this.fetchTasks()
-        })
-        .catch((e) => {
-          console.log('タスク完了(Online) >> 失敗')
-          console.error(e.message)
-        })
-
-      } else {
-        // オフラインの場合
-        promiseDoneTaskOnIDB
-        .then(() => {
-          // offline_taskに登録
-          return this.$db.offline_task.add({
-            'task_id': taskId,
-            'type': 'done',
-            'data': {
-              'task_id': taskId,
-              'feedback': taskFeedback,
-            }
-          })
-        })
-        .then(() => {
-          console.log('タスク完了(Offline) >> 成功')
-          this.errorMessage = 'タスク完了の同期に失敗しました。オンラインに復帰後同期します。'
-
-          // タスクデータの再読み込み
-          this.getTasksFromDB()
-        })
-        .catch((e) => {
-          console.log('タスク完了(Offline) >> 失敗')
-          console.error(e.message)
-        })
-      }
-      
     },
     fetchCategoryData() {
       console.log('fetchCategoryData()')

--- a/frontend/plugins/setup.js
+++ b/frontend/plugins/setup.js
@@ -1,0 +1,6 @@
+export default ({store}) => {
+  window.addEventListener('load', function() {
+    console.log('event: load')
+    store.dispatch('fetchAndApplyTasks')
+  })
+}

--- a/frontend/plugins/setup.js
+++ b/frontend/plugins/setup.js
@@ -2,5 +2,6 @@ export default ({store}) => {
   window.addEventListener('load', function() {
     console.log('event: load')
     store.dispatch('fetchAndApplyTasks')
+    store.dispatch('fetchAndApplyCategoryData')
   })
 }

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -1,8 +1,12 @@
 export const state = () => ({
   online: window.navigator.onLine,
+  tasks: null,
+  taskData: null,
+  categoryData: null,
 })
 
 export const mutations = {
+  // オンラインステータス
   changeStatusToOnline(state) {
     state.online = true
     console.log('online now')
@@ -10,11 +14,133 @@ export const mutations = {
   changeStatusToOffline(state) {
     state.online = false
     console.log('offline now')
-  }
+  },
+  // 
+  replaceTasks(state, tasks) {
+    state.tasks = tasks
+  },
+  replaceTaskData(state, taskData) {
+    // データを整形して保持
+    let newData = {}
+    taskData.forEach((task) => {
+      const taskId = task.id
+      delete task.id
+      newData[taskId] = task
+    })
+    // タスクデータの適用
+    state.taskData = newData
+  },
+  replaceCategoryData(state, categoryData) {
+    state.categoryData = categoryData
+  },
 }
 
 export const getters = {
   isOnline(state) {
-    return state.online;
+    return state.online
+  },
+  tasks(state) {
+    return state.tasks
+  },
+  taskData(state) {
+    return state.taskData
+  },
+}
+
+export const actions = {
+  fetchAndApplyTasks({dispatch, commit, state, getters}) {
+    console.log('fetchAndApplyTasks()')
+    const promiseGetTasks = dispatch('getTasksFromServer')
+    const promiseGetHistory = dispatch('getHistoryFromServer')
+
+    promiseGetTasks
+    .then(tasks => {
+      console.log('promiseGetTasks: tasks')
+      console.log(tasks)
+      return tasks
+    })
+    .then(tasks => dispatch('replaceIDBTaskWithNewTasks', tasks))
+
+    Promise.all([
+      promiseGetTasks,
+      promiseGetHistory
+    ])
+    .then((data) => {
+      console.log('promiseAll: data')
+      console.log(data)
+      const tasks = data[0]
+      const history = data[1]
+      // データを整形
+      let formattedTasks = []
+      tasks.forEach(task => {
+        const taskData = {
+          'task_id': task.id,
+          'date': task.next_display_date,
+          'is_done': false,
+        }
+        formattedTasks.push(taskData)
+      })
+      history.forEach((task) => {
+        const taskData = {
+          'date': task.completed_date,
+          'is_done': true,
+          'feedback': task.feedback,
+          'task_id': task.task_id,
+        }
+        formattedTasks.push(taskData)
+      })
+      return formattedTasks
+    })
+    .then(tasks => {
+      // test
+      console.log('tasks')
+      console.log(tasks)
+      return tasks
+    })
+    .then(tasks => dispatch('replaceIDBTaskDateWithNewTasks', tasks))
+    .then(() => {
+      return Promise.all([
+        dispatch('getTaskDataFromIDB')
+        .then(taskData => commit('replaceTaskData', taskData)),
+        dispatch('getTasksFromIDB')
+        .then(tasks => commit('replaceTasks', tasks))
+      ])
+    })
+    .then(() => {
+      // test
+      console.log('state.tasks:', state.tasks)
+      console.log('state.taskData:', state.taskData)
+      console.log('getters.tasks:', getters.tasks)
+      console.log('getters.taskData:', getters.taskData)
+    })
+    .catch(e => {
+      console.error('fetchAndApplyTasks Error:', e.message)
+    })
+  },
+  getTasksFromServer({state}) {
+    if (state.online) {
+      return this.$axios.get('/api/task/')
+      .then(response => response.data)
+    }
+  },
+  getHistoryFromServer({state}) {
+    if (state.online) {
+      return this.$axios.get('/api/history/')
+      .then(response => response.data)
+    }
+  },
+  getTasksFromIDB({}) {
+    return this.$db.task_date.toArray()
+  },
+  getTaskDataFromIDB({}) {
+    return this.$db.task.toArray()
+  },
+  replaceIDBTaskWithNewTasks({}, tasks) {
+    return this.$db.task.clear()
+    .then(() => this.$db.task.bulkAdd(tasks))
+  },
+  replaceIDBTaskDateWithNewTasks({}, tasks) {
+    return this.$db.task_date.clear()
+    .then(() => this.$db.task_date.bulkAdd(tasks))
   }
 }

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -489,7 +489,7 @@ export const actions = {
     }
   },
   updateTaskOnIDBTask({}, {taskId, data}) {
-    return this.$db.task.put({'id': taskId, ...data})
+    return this.$db.task.update({'id': taskId, ...data})
   },
   completeTaskOnServer({state}, {taskId, feedback}) {
     if (state.online) {

--- a/frontend/store/index.js
+++ b/frontend/store/index.js
@@ -54,7 +54,7 @@ export const getters = {
     return state.tasks
   },
   tasksToday(state) {
-    const today = new Date().toLocaleDateString().split('/').join('-')
+    const today = new Date().toLocaleDateString().replaceAll('/', '-')
     const tasks = state.tasks
     return tasks?.filter(task => task.date == today) ?? null
     // オプショナルチェイニング演算子


### PR DESCRIPTION
- タスクとカテゴリをVuexのStateで管理し、それを各ページで参照、子コンポーネントへpropsで渡しています。
- タスクやカテゴリのCRUD処理、完了処理をVuexのActions・Mutationsに移行しました。
- オフライン○○テーブルへの追加処理と、オフラインで新規作成した後にオフラインで更新や削除する場合の分岐を実装しました。

以下の修正も行っています。
- ホームで表示するタスクを当日のもののみに変更しています。
- 日付が日本の時間になっていないのを修正しています。
    - 日本時間で10月29日の1時9分に実行した場合
    - `new Date().toISOString() // '2021-10-28T16:09:04.719Z'`
    - `new Date().toLocaleString() // '2021/10/29 1:09:04'`
    - `new Date().toISOString().substr(0, 10) //  '2021-10-28'`
    - `new Date().toLocaleDateString().replaceAll('/', '-') // '2021-10-29' `
    - ただし、`new Date('2021-10-29').toLocaleString() // '2021/10/29 9:00:00'`

~typeがupdateやdeleteのものをOffline_○○に追加する際に、typeがcreateのタスクがすでに登録されている場合の処理を追加で実装中です。~